### PR TITLE
Add simple app for batch evaluation

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,4 +7,7 @@ if (NOT USE_WASM_COMPATIBLE_SOURCES)
 
     add_executable(marian-decoder-new marian-decoder-new.cpp)
     target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)
+
+    add_executable(translate translate.cpp)
+    target_link_libraries(translate PRIVATE bergamot-translator)
 endif()

--- a/app/translate.cpp
+++ b/app/translate.cpp
@@ -1,0 +1,44 @@
+/*
+ * translate.cpp
+ *
+ * An application which accepts line separated texts in stdin and returns translated ones in stdout.
+ * It is convenient for batch processing and can be used with tools like SacreBLEU.
+ *
+ */
+
+#include <iostream>
+#include <string>
+
+#include "AbstractTranslationModel.h"
+#include "TranslationRequest.h"
+#include "TranslationResult.h"
+#include "translator/parser.h"
+
+int main(int argc, char **argv) {
+
+  // Create a configParser and load command line parameters into a YAML config
+  // string.
+  auto configParser = marian::bergamot::createConfigParser();
+  auto options = configParser.parseOptions(argc, argv, true);
+  std::string config = options->asYamlString();
+
+  // Route the config string to construct marian model through
+  // AbstractTranslationModel
+  std::shared_ptr<AbstractTranslationModel> model =
+      AbstractTranslationModel::createInstance(config);
+
+  TranslationRequest translationRequest;
+  std::vector<std::string> texts;
+
+  for (std::string line; std::getline(std::cin, line);) {
+        texts.emplace_back(line);
+  }
+
+  auto results = model->translate(std::move(texts), translationRequest);
+
+  for (auto &result : results) {
+    std::cout << result.getTranslatedText() << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
To get BLEU scores with SacreBLEU I need a simple app that accepts line-separated texts in stdin and outputs results in stdout. It should use unified API, the same which is used from wasm to be as close to production usage as possible. The existing apps didn't work for me. Maybe it's better to fix one of them instead. @abhi-agg what do you think?