### PR TITLE
Downgraded resource class to 'medium' for circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: 'emscripten/emsdk:2.0.9'
-    resource_class: xlarge
+    resource_class: medium
 
     working_directory: ~/checkout
 

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -63,7 +63,7 @@ cd build-wasm
 
 #     2. Compile the artefacts
 emcmake cmake -DCOMPILE_WASM=on -DPACKAGE_DIR="../models/" ../
-emmake make -j
+emmake make -j3
 
 #     3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
 sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info,{simdWormhole:true});/g' wasm/bergamot-translator-worker.js


### PR DESCRIPTION
This PR will enable building browser extension from source (fixes the issue mentioned in the [comment](https://github.com/mozilla-extensions/bergamot-browser-extension/pull/41#issuecomment-784908303)).