### PR TITLE
Circle CI fixes to accommodate for upstream sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,19 @@ jobs:
           name: Build WASM
           command: bash build-wasm.sh
 
+      - run:
+          name: Check artifacts
+          working_directory: build-wasm
+          command: |
+            ls -all bergamot*
+            if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null && ls bergamot*.data &>/dev/null
+            then
+              echo "Artifacts Successfully Generated"
+            else
+              echo "Failure: Artifacts Not Present"
+              exit 1
+            fi
+
       - store_artifacts:
-          path: "build-wasm/wasm"
-          destination: "build-wasm/wasm"
+          path: "build-wasm"
+          destination: "build-wasm"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
 ### Build Natively
 1. Clone the repository using these instructions:
     ```bash
-    git clone https://github.com/browsermt/bergamot-translator
+    git clone https://github.com/mozilla/bergamot-translator
     cd bergamot-translator
     ```
 2. Compile
@@ -34,7 +34,7 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
 
 2. Clone the repository using these instructions:
     ```bash
-    git clone https://github.com/browsermt/bergamot-translator
+    git clone https://github.com/mozilla/bergamot-translator
     cd bergamot-translator
     ```
 

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -37,7 +37,7 @@ if [ "$EMSDK" == "" ]; then
   source ./emsdk/emsdk_env.sh
 fi
 
-# 3. Download models (only required if you want to package files in wasm binary)
+# 3. Download models (required to perform inference using build artifacts)
 if [ ! -d "bergamot-models" ]; then
   git clone --depth 1 --branch main --single-branch https://github.com/mozilla-applied-ml/bergamot-models
 else
@@ -53,21 +53,22 @@ mkdir -p models
 rm -rf models/*
 cp -rf bergamot-models/prod/* models
 gunzip models/*/*
+find models \( -type f -name "model*" -or -type f -name "lex*" \) -delete
 
 # 4. Compile
-#     1. Create a folder where you want to build all the artefacts (`build-wasm` in this case)
+#     1. Create a folder where you want to build all the artifacts (`build-wasm` in this case)
 if [ ! -d "build-wasm" ]; then
   mkdir build-wasm
 fi
 cd build-wasm
 
-#     2. Compile the artefacts
+#     2. Compile the artifacts
 emcmake cmake -DCOMPILE_WASM=on -DPACKAGE_DIR="../models/" ../
 emmake make -j3
 
 #     3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
 bash ../wasm/patch-artifacts-enable-wormhole.sh
 
-# The artifacts (.js and .wasm files) will be available in `wasm` folder of build directory ("build-wasm" in this case).
+# The artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).
 
 exit 0


### PR DESCRIPTION
Syncing with upstream changed following:
    - Wasm artifacts are built in different folder
    - Only vacabulary files need to be packaged in wasm binary

This PR:
- Changes the `build-wasm.sh` script used by circle CI
    -  Only vacabulary files are packaged in wasm binary

- Changes Circle CI yaml config
    - Added a check whether build artifacts are generated successfully or not
    - Changed the folder from where the wasm artifacts will be uploaded
    
- Changes README
    - Replace "browsermt" with "mozilla"