### PR TITLE
Extension-compatible artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           working_directory: build-wasm
           command: |
             ls -all bergamot*
-            if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null && ls bergamot*.data &>/dev/null
+            if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
             then
               echo "Artifacts Successfully Generated"
             else

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -37,24 +37,6 @@ if [ "$EMSDK" == "" ]; then
   source ./emsdk/emsdk_env.sh
 fi
 
-# 3. Download models (required to perform inference using build artifacts)
-if [ ! -d "bergamot-models" ]; then
-  git clone --depth 1 --branch main --single-branch https://github.com/mozilla-applied-ml/bergamot-models
-else
-  cd bergamot-models
-  git fetch
-  # Only pull if necessary
-  if [ $(git rev-parse HEAD) != $(git rev-parse @{u}) ]; then
-    git pull --ff-only
-  fi
-  cd -
-fi
-mkdir -p models
-rm -rf models/*
-cp -rf bergamot-models/prod/* models
-gunzip models/*/*
-find models \( -type f -name "model*" -or -type f -name "lex*" \) -delete
-
 # 4. Compile
 #     1. Create a folder where you want to build all the artifacts (`build-wasm` in this case)
 if [ ! -d "build-wasm" ]; then
@@ -63,7 +45,7 @@ fi
 cd build-wasm
 
 #     2. Compile the artifacts
-emcmake cmake -DCOMPILE_WASM=on -DPACKAGE_DIR="../models/" ../
+emcmake cmake -DCOMPILE_WASM=on ../
 emmake make -j3
 
 #     3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -26,8 +26,8 @@ set(LINKER_FLAGS "${LINKER_FLAGS} -lworkerfs.js")
 # Avoid node.js-code in emscripten glue-code
 set(LINKER_FLAGS "${LINKER_FLAGS} -s ENVIRONMENT=web,worker")
 
-# Don't run closure compiler on emscripted glue-code
-set(LINKER_FLAGS "${LINKER_FLAGS} --closure 0")
+# Don't minify emscripted glue-code
+set(LINKER_FLAGS "${LINKER_FLAGS} --profiling --minify 0 --closure 0")
 
 set_target_properties(bergamot-translator-worker PROPERTIES
                         SUFFIX ".js"

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -26,6 +26,9 @@ set(LINKER_FLAGS "${LINKER_FLAGS} -lworkerfs.js")
 # Avoid node.js-code in emscripten glue-code
 set(LINKER_FLAGS "${LINKER_FLAGS} -s ENVIRONMENT=web,worker")
 
+# Don't run closure compiler on emscripted glue-code
+set(LINKER_FLAGS "${LINKER_FLAGS} --closure 0")
+
 set_target_properties(bergamot-translator-worker PROPERTIES
                         SUFFIX ".js"
                         LINK_FLAGS ${LINKER_FLAGS}


### PR DESCRIPTION
A PR created to produce CI build artifacts that doesn't bundle any files, with glue code that is compatible with the bergamot-browser-extension.

EDIT: **Please don't merge this to `main` and don't close this PR.**